### PR TITLE
Adds support for `rclcpp_lifecycle::LifecycleNode` to `camera_info_manager`

### DIFF
--- a/camera_info_manager/CMakeLists.txt
+++ b/camera_info_manager/CMakeLists.txt
@@ -20,6 +20,7 @@ find_package(ament_cmake_ros REQUIRED)
 find_package(ament_index_cpp REQUIRED)
 find_package(camera_calibration_parsers REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
 find_package(rcpputils REQUIRED)
 find_package(sensor_msgs REQUIRED)
 
@@ -35,6 +36,7 @@ ament_target_dependencies(
   ament_index_cpp
   camera_calibration_parsers
   rclcpp
+  rclcpp_lifecycle
   rcpputils
   sensor_msgs
 )

--- a/camera_info_manager/include/camera_info_manager/camera_info_manager.hpp
+++ b/camera_info_manager/include/camera_info_manager/camera_info_manager.hpp
@@ -43,6 +43,7 @@
 #include <string>
 
 #include "rclcpp/node.hpp"
+#include "rclcpp_lifecycle/lifecycle_node.hpp"
 #include "sensor_msgs/msg/camera_info.hpp"
 #include "sensor_msgs/srv/set_camera_info.hpp"
 #include "camera_info_manager/visibility_control.h"
@@ -186,6 +187,20 @@ public:
     rclcpp::Node * node,
     const std::string & cname = "camera",
     const std::string & url = "");
+
+  CAMERA_INFO_MANAGER_PUBLIC
+  CameraInfoManager(
+    rclcpp_lifecycle::LifecycleNode * node,
+    const std::string & cname = "camera",
+    const std::string & url = "");
+
+  CAMERA_INFO_MANAGER_PUBLIC
+  CameraInfoManager(
+    rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_interface,
+    rclcpp::node_interfaces::NodeServicesInterface::SharedPtr node_services_interface,
+    rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logger_interface,
+    const std::string & cname = "camera", const std::string & url = "",
+    rmw_qos_profile_t custom_qos = rmw_qos_profile_default);
 
   CAMERA_INFO_MANAGER_PUBLIC
   CameraInfo getCameraInfo(void);

--- a/camera_info_manager/package.xml
+++ b/camera_info_manager/package.xml
@@ -23,6 +23,7 @@
   <depend>ament_index_cpp</depend>
   <depend>camera_calibration_parsers</depend>
   <depend>rclcpp</depend>
+  <depend>rclcpp_lifecycle</depend>
   <depend>rcpputils</depend>
   <depend>sensor_msgs</depend>
 


### PR DESCRIPTION
## This PR
Adds a base constructor to the `CameraInfoManager` class that allows this class to be constructed from base interfaces that are common to both `rclcpp::Node` and `rclcpp_lifecycle::LifecycleNode`. Additionally, another constructor is added that constructs this object by directly taking in a pointer to the `LifecycleNode`.